### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#rez [![GoDoc](https://godoc.org/github.com/bamiaux/rez/web?status.png)](https://godoc.org/github.com/bamiaux/rez) [![Build Status](https://travis-ci.org/bamiaux/rez.png)](https://travis-ci.org/bamiaux/rez)
+# rez [![GoDoc](https://godoc.org/github.com/bamiaux/rez/web?status.png)](https://godoc.org/github.com/bamiaux/rez) [![Build Status](https://travis-ci.org/bamiaux/rez.png)](https://travis-ci.org/bamiaux/rez)
 Package rez provides image resizing in pure Go and SIMD.
 
 Download:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
